### PR TITLE
Aafnan gui changes

### DIFF
--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
@@ -1,30 +1,24 @@
 package org.scheduleworks.dep;
 
-import java.awt.event.ActionEvent;
 import javafx.fxml.FXML;
-import javafx.scene.control.Label;
-import javafx.application.Application;
-import javafx.fxml.FXMLLoader;
-import javafx.geometry.Insets;
 import javafx.stage.Stage;
-import javafx.stage.StageStyle;
-import javafx.scene.Parent;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleButton;
 import javafx.scene.control.TextArea;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Scanner;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
-import javafx.scene.image.Image;
 import javafx.scene.text.Text;
 import java.io.IOException; 
 
 public class InterfaceController extends InterfaceMain {
     //  BUTTON LIST
+    @FXML
+    private Button btn_login_tab;
     @FXML
     private Text userText;
     @FXML
@@ -34,7 +28,14 @@ public class InterfaceController extends InterfaceMain {
     @FXML
     private Button loginButton;
     @FXML
+    private ToggleButton toggle_selenium_bg;
+    @FXML
+    private ToggleButton toggle_save_cookies;
+
+    @FXML
     private TextField code;
+    @FXML
+    private Button retrieveStartButton;
     @FXML
     private TextArea taCoursesTaken;
     @FXML
@@ -43,24 +44,24 @@ public class InterfaceController extends InterfaceMain {
     //  GLOBAL VARIABLES
     private static Stage stg;
     private double x, y = 0;
-    privateInfo userInfo = new privateInfo();
+    static privateInfo userInfo = new privateInfo();
 
     //  LOGIN TAB
     public void pressLoginTab() throws Exception {
         changeScene("InterfaceLogin.fxml");
-        System.out.println("Login tab pressed");    //  Test print, can be removed later
-        
-        //  FIX THIS if possible, comment out otherwise
-        changeUserText();
+
+        //changeUserText();         //  FIX THIS if possible, remove/comment out otherwise
     }
 
-    /*  This doesn't need to be in it's own method, this is just for debugging purposes  */
-    /*  since doing userInfo.setText doesn't execute correctly within pressLoginTab()    */
     public void changeUserText() throws Exception {
-        if (userInfo.getUsername() == "")
+        if (userInfo.getUsername() == "") {
             userText.setText("Not currently logged in ⚠");
-        else
+            //btn_login_tab.setText("Login");
+        }
+        else {
             userText.setText("Welcome " + userInfo.getUsername());
+            //btn_login_tab.setText("Welcome " + userInfo.getUsername());
+        }
     }
 
     public void pressLoginButton() throws Exception {
@@ -72,13 +73,78 @@ public class InterfaceController extends InterfaceMain {
         
         Thread t = new Thread(new pythonExecute(userInfo.getUsername(),userInfo.getPassword()));
         t.start();
+
+        username.clear();
+        password.clear();
     }
 
+    public void seleniumBackgroundButton() throws Exception {
+        boolean isSelected = toggle_selenium_bg.isSelected();
+        if (isSelected) {
+            toggle_selenium_bg.setText("On");
+            userInfo.setSeleniumToggle(true);
+        }
+        else {
+            toggle_selenium_bg.setText("Off");
+            userInfo.setSeleniumToggle(false);
+        }
+    }
+
+    public void saveCookiesButton() throws Exception {
+        boolean isSelected = toggle_save_cookies.isSelected();
+        if (isSelected) {
+            toggle_save_cookies.setText("On");
+            userInfo.setSaveCookiesToggle(true);
+        }
+        else {
+            toggle_save_cookies.setText("Off");
+            userInfo.setSaveCookiesToggle(false);
+        }
+    }
 
     //  RETRIEVE COURSES TAB
     public void retrieveCoursesTab() throws Exception {
         changeScene("InterfaceRetrieve.fxml");
+        /*   OLD CODE, DELETE LATER
         taCoursesTaken.clear();
+        File file = new File("C:\\Program Files\\ScheduleWorks\\data\\courseHistory.txt");
+        try {
+            if (file.createNewFile()) {
+                System.out.println("File created: " + file.getName());
+            } else {
+                System.out.println("File already exists.");
+            }
+        } catch (IOException e) {
+            System.out.println("An error occurred.");
+            e.printStackTrace();
+          }
+
+       try{
+        Scanner scan = new Scanner(file);
+        if (file.length()==0){
+            taCoursesTaken.clear();
+            taCoursesTaken.setPromptText("Please login and submit the 2FA Code");
+        }
+        while(scan.hasNextLine()){
+            taCoursesTaken.appendText(scan.nextLine() + "\n");
+            }
+        } 
+        catch (FileNotFoundException e){
+        e.printStackTrace();
+       }
+       */
+    }
+
+    public void pressRetrieveStartButton() throws Exception {
+        System.out.println("RETRIEVE START");
+        taCoursesTaken.clear();
+
+        //  No login info present
+        if (userInfo.getUsername() == "" || userInfo.getPassword() == "") {
+            taCoursesTaken.appendText("Username and/or password not entered\nEnter login info in the \"Login\" tab");
+            return;
+        }
+
         File file = new File("C:\\Program Files\\ScheduleWorks\\data\\courseHistory.txt");
         try {
             if (file.createNewFile()) {
@@ -107,6 +173,7 @@ public class InterfaceController extends InterfaceMain {
     }
 
     public void submitCode() {
+        System.out.println("Code submitted");
         try{
             BufferedWriter br = new BufferedWriter(new FileWriter(new File("C:\\Program Files\\ScheduleWorks\\schedule-works-be\\2fa_code.txt")));
             br.write(code.getText().toString());
@@ -122,6 +189,11 @@ public class InterfaceController extends InterfaceMain {
 
     public void viewCourseHistory(){
         stg.close();
+    }
+
+    //  RETRIEVE COURSES TAB
+    public void createScheduleTab() throws Exception {
+        changeScene("InterfaceCreateSchedule.fxml");
     }
 
     

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
@@ -76,16 +76,11 @@ public class InterfaceController {
         userInfo.setPassword(password.getText().toString());
         stg.close();
         
-        /*
-        InterfaceMain x = new InterfaceMain();
-        x.changeScene("Interface.fxml");
-        */
         Thread t = new Thread(new pythonExecute(userInfo.getUsername(),userInfo.getPassword()));
         t.start();
 
         System.out.println(userInfo.getUsername());
 
-        // System.out.println(userInfo.getPassword());
         closeApplication();
     }
 

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
@@ -23,7 +23,7 @@ import javafx.scene.image.Image;
 import java.io.IOException; 
 
 public class InterfaceController extends InterfaceMain {
-    //  Login menu
+    //  BUTTON LIST
     @FXML
     private TextField username;
     @FXML
@@ -36,56 +36,34 @@ public class InterfaceController extends InterfaceMain {
     private TextArea taCoursesTaken;
     @FXML
     private Button btn_submit_code;
+    //  Global variables
     private static Stage stg;
-
-    private double x,y=0;
+    private double x, y = 0;
     
+
+    //  LOGIN TAB
     public void pressLoginTab() throws Exception {
-        /*
-        FXMLLoader loader = new FXMLLoader(getClass().getClassLoader().getResource("InterfaceLogin.fxml"));
-
-        loader.setController(new InterfaceController());
-        Parent root = loader.load();
-        Stage loginStage = new Stage();
-
-        loginStage.getIcons().add(new Image(getClass().getClassLoader().getResourceAsStream("ScheduleWorksLogo.png")));
-        loginStage.initStyle(StageStyle.UNDECORATED);
-        stg = loginStage;
-        loginStage.setTitle("Login");
-        loginStage.setScene(new Scene(root));
-        loginStage.setResizable(false);
-
-        root.setOnMousePressed(mouseEvent ->{
-            x=mouseEvent.getSceneX();
-            y=mouseEvent.getSceneY();
-        });
-        root.setOnMouseDragged(mouseEvent ->{
-            loginStage.setX(mouseEvent.getScreenX()-x);
-            loginStage.setY(mouseEvent.getScreenY()-y);
-        });
-
-        // show the login page
-        loginStage.show();
-        */
-
         changeScene("InterfaceLogin.fxml");
+        System.out.println("Login tab pressed");    //  Test print, can be removed later
     }
 
-    public void pressLoginButton() throws Exception{
+    public void pressLoginButton() throws Exception {
         privateInfo userInfo = new privateInfo();
         userInfo.setUsername(username.getText().toString());
         userInfo.setPassword(password.getText().toString());
-        //stg.close();
-        changeScene("Interface.fxml");
+
+        System.out.println(userInfo.getUsername());     //  Test print, can be removed later
         
         Thread t = new Thread(new pythonExecute(userInfo.getUsername(),userInfo.getPassword()));
         t.start();
 
-        //closeApplication();
+        changeScene("Interface.fxml");
     }
 
-    //  Retrieve courses
-    public void retrieveCoursesTab(){
+
+    //  RETRIEVE COURSES TAB
+    public void retrieveCoursesTab() throws Exception {
+        changeScene("InterfaceRetrieve.fxml");
         taCoursesTaken.clear();
         File file = new File("C:\\Program Files\\ScheduleWorks\\data\\courseHistory.txt");
         try {

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
@@ -22,9 +22,7 @@ import java.io.FileWriter;
 import javafx.scene.image.Image;
 import java.io.IOException; 
 
-
-
-public class InterfaceController {
+public class InterfaceController extends InterfaceMain {
     //  Login menu
     @FXML
     private TextField username;
@@ -38,12 +36,14 @@ public class InterfaceController {
     private TextArea taCoursesTaken;
     @FXML
     private Button btn_submit_code;
-
     private static Stage stg;
+
     private double x,y=0;
     
     public void pressLoginTab() throws Exception {
+        /*
         FXMLLoader loader = new FXMLLoader(getClass().getClassLoader().getResource("InterfaceLogin.fxml"));
+
         loader.setController(new InterfaceController());
         Parent root = loader.load();
         Stage loginStage = new Stage();
@@ -55,7 +55,6 @@ public class InterfaceController {
         loginStage.setScene(new Scene(root));
         loginStage.setResizable(false);
 
-
         root.setOnMousePressed(mouseEvent ->{
             x=mouseEvent.getSceneX();
             y=mouseEvent.getSceneY();
@@ -65,23 +64,24 @@ public class InterfaceController {
             loginStage.setY(mouseEvent.getScreenY()-y);
         });
 
-        loginStage.show();// show the login page
+        // show the login page
+        loginStage.show();
+        */
 
-        System.out.println("Login tab pressed");
+        changeScene("InterfaceLogin.fxml");
     }
 
     public void pressLoginButton() throws Exception{
         privateInfo userInfo = new privateInfo();
         userInfo.setUsername(username.getText().toString());
         userInfo.setPassword(password.getText().toString());
-        stg.close();
+        //stg.close();
+        changeScene("Interface.fxml");
         
         Thread t = new Thread(new pythonExecute(userInfo.getUsername(),userInfo.getPassword()));
         t.start();
 
-        System.out.println(userInfo.getUsername());
-
-        closeApplication();
+        //closeApplication();
     }
 
     //  Retrieve courses
@@ -137,9 +137,11 @@ public class InterfaceController {
     //  Close application
     @FXML private javafx.scene.control.Button Close_button;
 
-    public void closeApplication() throws Exception{
+    public void closeApplication() throws Exception {
         Stage stage = (Stage) Close_button.getScene().getWindow();
         stage.close(); // this is to close the Application.
         System.out.println("Application closed");
+
+        System.exit(0);
     }
 }

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceController.java
@@ -20,10 +20,13 @@ import java.util.Scanner;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import javafx.scene.image.Image;
+import javafx.scene.text.Text;
 import java.io.IOException; 
 
 public class InterfaceController extends InterfaceMain {
     //  BUTTON LIST
+    @FXML
+    private Text userText;
     @FXML
     private TextField username;
     @FXML
@@ -36,28 +39,39 @@ public class InterfaceController extends InterfaceMain {
     private TextArea taCoursesTaken;
     @FXML
     private Button btn_submit_code;
-    //  Global variables
+
+    //  GLOBAL VARIABLES
     private static Stage stg;
     private double x, y = 0;
-    
+    privateInfo userInfo = new privateInfo();
 
     //  LOGIN TAB
     public void pressLoginTab() throws Exception {
         changeScene("InterfaceLogin.fxml");
         System.out.println("Login tab pressed");    //  Test print, can be removed later
+        
+        //  FIX THIS if possible, comment out otherwise
+        changeUserText();
+    }
+
+    /*  This doesn't need to be in it's own method, this is just for debugging purposes  */
+    /*  since doing userInfo.setText doesn't execute correctly within pressLoginTab()    */
+    public void changeUserText() throws Exception {
+        if (userInfo.getUsername() == "")
+            userText.setText("Not currently logged in ⚠");
+        else
+            userText.setText("Welcome " + userInfo.getUsername());
     }
 
     public void pressLoginButton() throws Exception {
-        privateInfo userInfo = new privateInfo();
         userInfo.setUsername(username.getText().toString());
         userInfo.setPassword(password.getText().toString());
+        changeUserText();
 
         System.out.println(userInfo.getUsername());     //  Test print, can be removed later
         
         Thread t = new Thread(new pythonExecute(userInfo.getUsername(),userInfo.getPassword()));
         t.start();
-
-        changeScene("Interface.fxml");
     }
 
 

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
@@ -12,7 +12,7 @@ import javafx.scene.image.Image;
 
 public class InterfaceMain extends Application{
     private static Stage stg;
-    private double x,y=0;
+    private double x,y = 0;
 
     public static void main(String[] args){
         launch(args); // necessary to start the application
@@ -27,7 +27,6 @@ public class InterfaceMain extends Application{
 
         primaryStage.getIcons().add(new Image(getClass().getClassLoader().getResourceAsStream("ScheduleWorksLogo.png")));
         primaryStage.initStyle(StageStyle.DECORATED);
-        primaryStage.sizeToScene();
         primaryStage.setTitle("ScheduleWorks"); // Title of the page of Interface
         primaryStage.setScene(new Scene(root)); // sets up the size of the interface showm in the scene 
         primaryStage.setMinWidth(900);
@@ -44,12 +43,16 @@ public class InterfaceMain extends Application{
 
         primaryStage.setResizable(true); // cannot change the size of the screen
         primaryStage.show();
-        
+
     }
     
 
     public void changeScene(String fxml) throws Exception {
-        Parent pane = FXMLLoader.load(getClass().getResource(fxml));
-        stg.getScene().setRoot(pane);
+        FXMLLoader loader = new FXMLLoader(getClass().getClassLoader().getResource(fxml));
+        loader.setController(new InterfaceController());
+        Parent root = loader.load();
+
+        Scene newScene = new Scene(root);
+        stg.setScene(newScene);
     }
 }

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
@@ -1,18 +1,21 @@
 package org.scheduleworks.dep;
 
+import javafx.animation.FadeTransition;
 import javafx.application.Application;
+import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.layout.*;
-import javafx.scene.control.*;
 import javafx.scene.image.Image;
+import javafx.scene.layout.StackPane;
+import javafx.util.Duration;
 
 public class InterfaceMain extends Application{
     private static Stage stg;
-    private double x,y = 0;
+    private double x, y = 0;
+    //static privateInfo userInfo = new privateInfo();
 
     public static void main(String[] args){
         launch(args); // necessary to start the application
@@ -43,9 +46,8 @@ public class InterfaceMain extends Application{
             primaryStage.setY(mouseEvent.getScreenY()-y);
         });
 
-        primaryStage.setResizable(true); // cannot change the size of the screen
+        primaryStage.setResizable(true);
         primaryStage.show();
-
     }
     
 
@@ -55,6 +57,15 @@ public class InterfaceMain extends Application{
         Parent root = loader.load();
 
         Scene newScene = new Scene(root);
+        //fadeOut();
         stg.setScene(newScene);
+    }
+
+    @FXML
+    private StackPane rootPane;
+    void fadeOut() {
+        FadeTransition fadeInTransition = new FadeTransition(Duration.millis(1500));
+        fadeInTransition.setFromValue(0.0);
+        fadeInTransition.setToValue(1.0);
     }
 }

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
@@ -19,16 +19,19 @@ public class InterfaceMain extends Application{
     }
 
     @Override
-    public void start(Stage primaryStage) throws Exception{
+    public void start(Stage primaryStage) throws Exception {
         stg = primaryStage;
         FXMLLoader loader = new FXMLLoader(getClass().getClassLoader().getResource("Interface.fxml"));
         loader.setController(new InterfaceController());
         Parent root = loader.load();
+
         primaryStage.getIcons().add(new Image(getClass().getClassLoader().getResourceAsStream("ScheduleWorksLogo.png")));
-        primaryStage.initStyle(StageStyle.UNDECORATED);
-        primaryStage.setTitle("ScheduleWorks");// Title of the page of Interface
+        primaryStage.initStyle(StageStyle.DECORATED);
+        primaryStage.sizeToScene();
+        primaryStage.setTitle("ScheduleWorks"); // Title of the page of Interface
         primaryStage.setScene(new Scene(root)); // sets up the size of the interface showm in the scene 
-        
+        primaryStage.setMinWidth(900);
+        primaryStage.setMinHeight(650);
 
         root.setOnMousePressed(mouseEvent ->{
             x=mouseEvent.getSceneX();
@@ -39,13 +42,13 @@ public class InterfaceMain extends Application{
             primaryStage.setY(mouseEvent.getScreenY()-y);
         });
 
-        primaryStage.setResizable(false); // cannot change the size of the screen
+        primaryStage.setResizable(true); // cannot change the size of the screen
         primaryStage.show();
         
     }
     
 
-    public void changeScene(String fxml) throws Exception{
+    public void changeScene(String fxml) throws Exception {
         Parent pane = FXMLLoader.load(getClass().getResource(fxml));
         stg.getScene().setRoot(pane);
     }

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
@@ -29,8 +29,8 @@ public class InterfaceMain extends Application{
         primaryStage.initStyle(StageStyle.DECORATED);
         primaryStage.setTitle("ScheduleWorks"); // Title of the page of Interface
         primaryStage.setScene(new Scene(root)); // sets up the size of the interface showm in the scene 
-        primaryStage.setMinWidth(900);
-        primaryStage.setMinHeight(650);
+        primaryStage.setMinWidth(1200);
+        primaryStage.setMinHeight(800);
 
         root.setOnMousePressed(mouseEvent ->{
             x=mouseEvent.getSceneX();

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
@@ -29,9 +29,9 @@ public class InterfaceMain extends Application{
         primaryStage.initStyle(StageStyle.DECORATED);
         primaryStage.setTitle("ScheduleWorks"); // Title of the page of Interface
         primaryStage.setScene(new Scene(root)); // sets up the size of the interface showm in the scene 
-        primaryStage.setMinWidth(1200);
+        primaryStage.setMinWidth(1280);
         primaryStage.setMinHeight(800);
-        primaryStage.setWidth(1200);
+        primaryStage.setWidth(1280);
         primaryStage.setHeight(800);
 
         root.setOnMousePressed(mouseEvent ->{

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/InterfaceMain.java
@@ -31,6 +31,8 @@ public class InterfaceMain extends Application{
         primaryStage.setScene(new Scene(root)); // sets up the size of the interface showm in the scene 
         primaryStage.setMinWidth(1200);
         primaryStage.setMinHeight(800);
+        primaryStage.setWidth(1200);
+        primaryStage.setHeight(800);
 
         root.setOnMousePressed(mouseEvent ->{
             x=mouseEvent.getSceneX();

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/SWButtonSkin.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/SWButtonSkin.java
@@ -1,0 +1,25 @@
+package org.scheduleworks.dep;
+
+import javafx.animation.FadeTransition;
+import javafx.scene.control.Button;
+import javafx.scene.control.skin.ButtonSkin;
+import javafx.util.Duration;
+
+public class SWButtonSkin extends ButtonSkin {
+    public SWButtonSkin(Button control) {
+        super(control);
+
+        final FadeTransition fadeIn = new FadeTransition(Duration.millis(100));
+        fadeIn.setNode(control);
+        fadeIn.setToValue(1);
+        control.setOnMouseEntered(e -> fadeIn.playFromStart());
+
+        final FadeTransition fadeOut = new FadeTransition(Duration.millis(100));
+        fadeOut.setNode(control);
+        fadeOut.setToValue(0.88);
+        control.setOnMouseExited(e -> fadeOut.playFromStart());
+
+        control.setOpacity(0.88);
+    }
+
+}

--- a/schedule-works-fe/src/main/java/org/scheduleworks/dep/privateInfo.java
+++ b/schedule-works-fe/src/main/java/org/scheduleworks/dep/privateInfo.java
@@ -1,14 +1,19 @@
 package org.scheduleworks.dep;
-//  Private info class for login, for testing login
+//  Private info class for login & app settings
 
 public class privateInfo {
     //  Username and password
     private String username;
     private String password;
+    //  App settings toggles
+    private boolean seleniumToggle;
+    private boolean saveCookiesToggle;
 
     public privateInfo() {
         setUsername("");
         setPassword("");
+        setSeleniumToggle(true);
+        setSaveCookiesToggle(true);
     }
 
     protected void setUsername(String username) {
@@ -22,5 +27,18 @@ public class privateInfo {
     }
     protected String getPassword() {
         return password;
+    }
+
+    protected void setSeleniumToggle(boolean seleniumToggle) {
+        this.seleniumToggle = seleniumToggle;
+    }
+    protected boolean getSeleniumToggle() {
+        return seleniumToggle;
+    }
+    protected void setSaveCookiesToggle(boolean saveCookiesToggle) {
+        this.saveCookiesToggle = saveCookiesToggle;
+    }
+    protected boolean getSaveCookiesToggle() {
+        return saveCookiesToggle;
     }
 }

--- a/schedule-works-fe/src/main/resources/Interface.fxml
+++ b/schedule-works-fe/src/main/resources/Interface.fxml
@@ -18,7 +18,7 @@
 <!-- this fxml code is created through scene builder, you can edit the code here manually or
 you can put your changes in to the scene builder and you can see your results accordingly in here as well -->
 
-<AnchorPane fx:id="scenePane" minHeight="-Infinity" minWidth="-Infinity" prefHeight="650.0" prefWidth="900.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane fx:id="scenePane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="1280.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <AnchorPane layoutY="52.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="598.0" prefWidth="277.0" style="-fx-background-color: #0F5F52;" AnchorPane.bottomAnchor="0.0" AnchorPane.topAnchor="52.0">
          <children>
@@ -45,7 +45,7 @@ you can put your changes in to the scene builder and you can see your results ac
                         <Cursor fx:constant="HAND" />
                      </cursor>
                   </Button>
-                  <Button fx:id="btn_retrieve_tab" mnemonicParsing="false" onAction="#retrieveCoursesTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Retrieve Courses" textAlignment="CENTER" textFill="WHITE" wrapText="true">
+                  <Button fx:id="btn_retrieve_tab" mnemonicParsing="false" onAction="#retrieveCoursesTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Retrieve Courses" textFill="WHITE">
                      <font>
                         <Font name="Century Gothic Bold" size="26.0" />
                      </font>
@@ -55,9 +55,22 @@ you can put your changes in to the scene builder and you can see your results ac
                   </Button>
                </children>
             </VBox>
+            <TextField id="code" fx:id="code" layoutX="39.0" layoutY="618.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
+               <font>
+                  <Font name="Century Gothic Bold" size="17.0" />
+               </font>
+            </TextField>
+            <Button fx:id="btn_submit_code" layoutX="151.0" layoutY="618.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
+               <font>
+                  <Font name="Century Gothic Bold" size="20.0" />
+               </font>
+               <cursor>
+                  <Cursor fx:constant="HAND" />
+               </cursor>
+            </Button>
          </children>
       </AnchorPane>
-      <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="539.0" prefWidth="563.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="30.0" AnchorPane.topAnchor="83.0">
+      <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="944.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" visible="false" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">
          <cursor>
             <Cursor fx:constant="DEFAULT" />
          </cursor>
@@ -80,7 +93,7 @@ you can put your changes in to the scene builder and you can see your results ac
                      </HBox.margin>
                   </Label>
                   <Region prefHeight="45.0" prefWidth="617.0" HBox.hgrow="ALWAYS" />
-                  <Button id="Close_button" fx:id="Close_button" alignment="CENTER_RIGHT" mnemonicParsing="false" onAction="#closeApplication" onMouseClicked="#closeApplication" prefHeight="46.0" prefWidth="46.0" styleClass="Close_button" stylesheets="@MainWindowStyle.css" text="x" textAlignment="CENTER" textFill="WHITE" translateY="-2.0" HBox.hgrow="ALWAYS">
+                  <Button id="Close_button" fx:id="Close_button" alignment="CENTER" mnemonicParsing="false" onAction="#closeApplication" onMouseClicked="#closeApplication" prefHeight="46.0" prefWidth="46.0" styleClass="Close_button" stylesheets="@MainWindowStyle.css" text="x" textAlignment="CENTER" textFill="WHITE" translateY="-2.0" visible="false" HBox.hgrow="ALWAYS">
                      <font>
                         <Font name="Century Gothic Bold" size="20.0" />
                      </font>
@@ -92,18 +105,5 @@ you can put your changes in to the scene builder and you can see your results ac
             </HBox>
          </children>
       </AnchorPane>
-      <TextField id="code" fx:id="code" layoutX="455.0" layoutY="191.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
-         <font>
-            <Font name="Century Gothic Bold" size="17.0" />
-         </font>
-      </TextField>
-      <Button fx:id="btn_submit_code" layoutX="567.0" layoutY="191.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
-         <font>
-            <Font name="Century Gothic Bold" size="20.0" />
-         </font>
-         <cursor>
-            <Cursor fx:constant="HAND" />
-         </cursor>
-      </Button>
    </children>
 </AnchorPane>

--- a/schedule-works-fe/src/main/resources/Interface.fxml
+++ b/schedule-works-fe/src/main/resources/Interface.fxml
@@ -11,6 +11,7 @@
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
@@ -19,7 +20,7 @@ you can put your changes in to the scene builder and you can see your results ac
 
 <AnchorPane fx:id="scenePane" minHeight="-Infinity" minWidth="-Infinity" prefHeight="650.0" prefWidth="900.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <AnchorPane layoutY="52.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="598.0" prefWidth="277.0" style="-fx-background-color: #0F5F52;">
+      <AnchorPane layoutY="52.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="598.0" prefWidth="277.0" style="-fx-background-color: #0F5F52;" AnchorPane.bottomAnchor="0.0" AnchorPane.topAnchor="52.0">
          <children>
             <ImageView fitHeight="202.0" fitWidth="183.0" layoutX="47.0" layoutY="31.0" pickOnBounds="true" preserveRatio="true">
                <image>
@@ -56,7 +57,7 @@ you can put your changes in to the scene builder and you can see your results ac
             </VBox>
          </children>
       </AnchorPane>
-      <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="365.0" layoutY="77.0" opacity="0.7" prefHeight="531.0" prefWidth="477.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" wrapText="true">
+      <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="539.0" prefWidth="563.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="30.0" AnchorPane.topAnchor="83.0">
          <cursor>
             <Cursor fx:constant="DEFAULT" />
          </cursor>
@@ -66,18 +67,22 @@ you can put your changes in to the scene builder and you can see your results ac
          <font>
             <Font name="Century Gothic Bold" size="14.0" />
          </font></TextArea>
-      <AnchorPane prefHeight="49.0" prefWidth="872.0" styleClass="topbar" stylesheets="@MainWindowStyle.css">
+      <AnchorPane prefHeight="49.0" prefWidth="872.0" styleClass="topbar" stylesheets="@MainWindowStyle.css" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
          <children>
-            <HBox alignment="CENTER_RIGHT" maxWidth="1.7976931348623157E308" prefHeight="55.0" prefWidth="900.0">
+            <HBox alignment="CENTER_RIGHT" nodeOrientation="LEFT_TO_RIGHT" prefHeight="55.0" prefWidth="900.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                <children>
-                  <Label text="ScheduleWorks                                                                            " textFill="WHITE">
+                  <Label text="ScheduleWorks  " textAlignment="CENTER" textFill="WHITE" textOverrun="CLIP" HBox.hgrow="ALWAYS">
                      <font>
                         <Font name="Century Gothic Bold" size="29.0" />
                      </font>
+                     <HBox.margin>
+                        <Insets />
+                     </HBox.margin>
                   </Label>
-                  <Button id="Close_button" fx:id="Close_button" mnemonicParsing="false" onAction="#closeApplication" onMouseClicked="#closeApplication" prefHeight="46.0" prefWidth="46.0" styleClass="Close_button" stylesheets="@MainWindowStyle.css" text="X" textFill="WHITE">
+                  <Region prefHeight="45.0" prefWidth="617.0" HBox.hgrow="ALWAYS" />
+                  <Button id="Close_button" fx:id="Close_button" alignment="CENTER_RIGHT" mnemonicParsing="false" onAction="#closeApplication" onMouseClicked="#closeApplication" prefHeight="46.0" prefWidth="46.0" styleClass="Close_button" stylesheets="@MainWindowStyle.css" text="x" textAlignment="CENTER" textFill="WHITE" translateY="-2.0" HBox.hgrow="ALWAYS">
                      <font>
-                        <Font name="Century Gothic Bold" size="12.0" />
+                        <Font name="Century Gothic Bold" size="20.0" />
                      </font>
                   </Button>
                </children>

--- a/schedule-works-fe/src/main/resources/Interface.fxml
+++ b/schedule-works-fe/src/main/resources/Interface.fxml
@@ -5,7 +5,6 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextArea?>
-<?import javafx.scene.control.TextField?>
 <?import javafx.scene.effect.Shadow?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
@@ -53,21 +52,16 @@ you can put your changes in to the scene builder and you can see your results ac
                         <Cursor fx:constant="HAND" />
                      </cursor>
                   </Button>
+                  <Button fx:id="btn_create_schedule" mnemonicParsing="false" onAction="#createScheduleTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Create Schedule" textFill="WHITE" wrapText="true">
+                     <font>
+                        <Font name="Century Gothic Bold" size="26.0" />
+                     </font>
+                     <cursor>
+                        <Cursor fx:constant="HAND" />
+                     </cursor>
+                  </Button>
                </children>
             </VBox>
-            <TextField id="code" fx:id="code" layoutX="39.0" layoutY="618.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
-               <font>
-                  <Font name="Century Gothic Bold" size="17.0" />
-               </font>
-            </TextField>
-            <Button fx:id="btn_submit_code" layoutX="151.0" layoutY="618.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
-               <font>
-                  <Font name="Century Gothic Bold" size="20.0" />
-               </font>
-               <cursor>
-                  <Cursor fx:constant="HAND" />
-               </cursor>
-            </Button>
          </children>
       </AnchorPane>
       <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="944.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" visible="false" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">

--- a/schedule-works-fe/src/main/resources/Interface.fxml
+++ b/schedule-works-fe/src/main/resources/Interface.fxml
@@ -11,16 +11,17 @@
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
 <!-- this fxml code is created through scene builder, you can edit the code here manually or
 you can put your changes in to the scene builder and you can see your results accordingly in here as well -->
 
-<AnchorPane fx:id="scenePane" prefHeight="650.0" prefWidth="900.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane fx:id="scenePane" minHeight="-Infinity" minWidth="-Infinity" prefHeight="650.0" prefWidth="900.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <AnchorPane layoutY="52.0" prefHeight="598.0" prefWidth="321.0" style="-fx-background-color: #0F5F52;">
+      <AnchorPane layoutY="52.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="598.0" prefWidth="277.0" style="-fx-background-color: #0F5F52;">
          <children>
-            <ImageView fitHeight="202.0" fitWidth="183.0" layoutX="68.0" layoutY="36.0" pickOnBounds="true" preserveRatio="true">
+            <ImageView fitHeight="202.0" fitWidth="183.0" layoutX="47.0" layoutY="31.0" pickOnBounds="true" preserveRatio="true">
                <image>
                   <Image url="@ScheduleWorksLogo.png" />
                </image>
@@ -28,40 +29,31 @@ you can put your changes in to the scene builder and you can see your results ac
                   <Shadow />
                </effect>
             </ImageView>
-            <Button fx:id="btn_login_tab" graphicTextGap="0.0" layoutX="64.0" layoutY="258.0" mnemonicParsing="false" onAction="#pressLoginTab" prefHeight="47.0" prefWidth="200.0" styleClass="general_button" text="Login" textFill="WHITE">
-               <font>
-                  <Font name="Century Gothic Bold" size="32.0" />
-               </font>
-               <cursor>
-                  <Cursor fx:constant="HAND" />
-               </cursor>
-            </Button>
-            <Button fx:id="btn_retrieve_tab" layoutX="64.0" layoutY="449.0" mnemonicParsing="false" onAction="#retrieveCoursesTab" prefHeight="116.0" prefWidth="200.0" styleClass="general_button" text="Retrieve Courses" textAlignment="CENTER" textFill="WHITE" wrapText="true">
-               <font>
-                  <Font name="Century Gothic Bold" size="30.0" />
-               </font>
-               <cursor>
-                  <Cursor fx:constant="HAND" />
-               </cursor>
-            </Button>
-            <ImageView fitHeight="187.0" fitWidth="178.0" layoutX="76.0" layoutY="42.0" pickOnBounds="true" preserveRatio="true">
+            <ImageView fitHeight="187.0" fitWidth="178.0" layoutX="55.0" layoutY="37.0" pickOnBounds="true" preserveRatio="true">
                <image>
                   <Image url="@ScheduleWorksLogo.png" />
                </image>
             </ImageView>
-            <TextField id="code" fx:id="code" layoutX="57.0" layoutY="351.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
-               <font>
-                  <Font name="Century Gothic Bold" size="17.0" />
-               </font>
-            </TextField>
-            <Button fx:id="btn_submit_code" layoutX="169.0" layoutY="351.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
-               <font>
-                  <Font name="Century Gothic Bold" size="20.0" />
-               </font>
-               <cursor>
-                  <Cursor fx:constant="HAND" />
-               </cursor>
-            </Button>
+            <VBox layoutX="-1.0" layoutY="257.0" prefHeight="341.0" prefWidth="277.0">
+               <children>
+                  <Button fx:id="btn_login_tab" graphicTextGap="0.0" mnemonicParsing="false" onAction="#pressLoginTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Login" textFill="WHITE">
+                     <font>
+                        <Font name="Century Gothic Bold" size="26.0" />
+                     </font>
+                     <cursor>
+                        <Cursor fx:constant="HAND" />
+                     </cursor>
+                  </Button>
+                  <Button fx:id="btn_retrieve_tab" mnemonicParsing="false" onAction="#retrieveCoursesTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Retrieve Courses" textAlignment="CENTER" textFill="WHITE" wrapText="true">
+                     <font>
+                        <Font name="Century Gothic Bold" size="26.0" />
+                     </font>
+                     <cursor>
+                        <Cursor fx:constant="HAND" />
+                     </cursor>
+                  </Button>
+               </children>
+            </VBox>
          </children>
       </AnchorPane>
       <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="365.0" layoutY="77.0" opacity="0.7" prefHeight="531.0" prefWidth="477.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" wrapText="true">
@@ -76,7 +68,7 @@ you can put your changes in to the scene builder and you can see your results ac
          </font></TextArea>
       <AnchorPane prefHeight="49.0" prefWidth="872.0" styleClass="topbar" stylesheets="@MainWindowStyle.css">
          <children>
-            <HBox alignment="CENTER_RIGHT" prefHeight="55.0" prefWidth="900.0">
+            <HBox alignment="CENTER_RIGHT" maxWidth="1.7976931348623157E308" prefHeight="55.0" prefWidth="900.0">
                <children>
                   <Label text="ScheduleWorks                                                                            " textFill="WHITE">
                      <font>
@@ -95,5 +87,18 @@ you can put your changes in to the scene builder and you can see your results ac
             </HBox>
          </children>
       </AnchorPane>
+      <TextField id="code" fx:id="code" layoutX="455.0" layoutY="191.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
+         <font>
+            <Font name="Century Gothic Bold" size="17.0" />
+         </font>
+      </TextField>
+      <Button fx:id="btn_submit_code" layoutX="567.0" layoutY="191.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
+         <font>
+            <Font name="Century Gothic Bold" size="20.0" />
+         </font>
+         <cursor>
+            <Cursor fx:constant="HAND" />
+         </cursor>
+      </Button>
    </children>
 </AnchorPane>

--- a/schedule-works-fe/src/main/resources/InterfaceCreateSchedule.fxml
+++ b/schedule-works-fe/src/main/resources/InterfaceCreateSchedule.fxml
@@ -5,7 +5,6 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextArea?>
-<?import javafx.scene.control.TextField?>
 <?import javafx.scene.effect.Shadow?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
@@ -109,13 +108,13 @@ you can put your changes in to the scene builder and you can see your results ac
       </AnchorPane>
       <AnchorPane layoutX="291.0" layoutY="69.0" prefHeight="716.0" prefWidth="975.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="291.0" AnchorPane.rightAnchor="14.0" AnchorPane.topAnchor="69.0">
          <children>
-            <Text id="userText" fill="WHITE" layoutX="2.0" layoutY="30.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Retrieve Courses">
+            <Text id="userText" fill="WHITE" layoutX="2.0" layoutY="30.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Create Schedule">
                <font>
                   <Font name="Century Gothic Bold" size="35.0" />
                </font>
             </Text>
             <Line endX="711.5" layoutX="255.0" layoutY="48.0" startX="-252.0" stroke="WHITE" strokeWidth="5.0" AnchorPane.bottomAnchor="665.5" AnchorPane.leftAnchor="0.5" AnchorPane.rightAnchor="6.0" AnchorPane.topAnchor="45.5" />
-            <Text fill="WHITE" layoutX="24.0" layoutY="104.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Enter the 2FA code below if prompted" wrappingWidth="357.21875">
+            <Text fill="WHITE" layoutX="24.0" layoutY="104.0" strokeType="OUTSIDE" strokeWidth="0.0" text="This page isn't done yet Check back later" wrappingWidth="357.21875">
                <font>
                   <Font name="Century Gothic Bold" size="25.0" />
                </font>
@@ -131,20 +130,7 @@ you can put your changes in to the scene builder and you can see your results ac
                   <Font name="Century Gothic Bold" size="14.0" />
                </font>
             </TextArea>
-            <TextField id="code" fx:id="code" layoutX="24.0" layoutY="157.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
-               <font>
-                  <Font name="Century Gothic Bold" size="17.0" />
-               </font>
-            </TextField>
-            <Button fx:id="btn_submit_code" layoutX="130.0" layoutY="157.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
-               <font>
-                  <Font name="Century Gothic Bold" size="20.0" />
-               </font>
-               <cursor>
-                  <Cursor fx:constant="HAND" />
-               </cursor>
-            </Button>
-            <Button fx:id="retrieveStartButton" alignment="CENTER" layoutX="230.0" layoutY="623.0" mnemonicParsing="false" onAction="#pressRetrieveStartButton" prefHeight="47.0" prefWidth="151.0" styleClass="general_button" stylesheets="@MainWindowStyle.css" text="  Start➧" textAlignment="CENTER" textFill="WHITE" textOverrun="CLIP">
+            <Button alignment="CENTER" layoutX="230.0" layoutY="623.0" mnemonicParsing="false" onAction="#pressRetrieveStartButton" prefHeight="47.0" prefWidth="151.0" styleClass="general_button" stylesheets="@MainWindowStyle.css" text="  Start➧" textAlignment="CENTER" textFill="WHITE" textOverrun="CLIP">
                <font>
                   <Font name="Century Gothic Bold" size="24.0" />
                </font>

--- a/schedule-works-fe/src/main/resources/InterfaceLogin.fxml
+++ b/schedule-works-fe/src/main/resources/InterfaceLogin.fxml
@@ -10,6 +10,7 @@ you can put your changes in to the scene builder and you can see your results ac
 <?import javafx.scene.control.PasswordField?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.ToggleButton?>
 <?import javafx.scene.effect.Shadow?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
@@ -23,7 +24,7 @@ you can put your changes in to the scene builder and you can see your results ac
 
 <AnchorPane prefHeight="400.0" prefWidth="550.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <AnchorPane fx:id="scenePane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="1280.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+      <AnchorPane fx:id="scenePane1" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="1280.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
          <children>
             <AnchorPane layoutY="52.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="598.0" prefWidth="277.0" style="-fx-background-color: #0F5F52;" AnchorPane.bottomAnchor="0.0" AnchorPane.topAnchor="52.0">
                <children>
@@ -42,7 +43,7 @@ you can put your changes in to the scene builder and you can see your results ac
                   </ImageView>
                   <VBox layoutX="-1.0" layoutY="257.0" prefHeight="341.0" prefWidth="277.0">
                      <children>
-                        <Button fx:id="btn_login_tab" graphicTextGap="0.0" mnemonicParsing="false" onAction="#pressLoginTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Login" textFill="WHITE">
+                        <Button fx:id="btn_login_tab1" graphicTextGap="0.0" mnemonicParsing="false" onAction="#pressLoginTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Login" textFill="WHITE">
                            <font>
                               <Font name="Century Gothic Bold" size="26.0" />
                            </font>
@@ -50,7 +51,15 @@ you can put your changes in to the scene builder and you can see your results ac
                               <Cursor fx:constant="HAND" />
                            </cursor>
                         </Button>
-                        <Button fx:id="btn_retrieve_tab" mnemonicParsing="false" onAction="#retrieveCoursesTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Retrieve Courses" textFill="WHITE">
+                        <Button fx:id="btn_retrieve_tab1" mnemonicParsing="false" onAction="#retrieveCoursesTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Retrieve Courses" textFill="WHITE">
+                           <font>
+                              <Font name="Century Gothic Bold" size="26.0" />
+                           </font>
+                           <cursor>
+                              <Cursor fx:constant="HAND" />
+                           </cursor>
+                        </Button>
+                        <Button fx:id="btn_create_schedule" mnemonicParsing="false" onAction="#createScheduleTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Create Schedule" textFill="WHITE" wrapText="true">
                            <font>
                               <Font name="Century Gothic Bold" size="26.0" />
                            </font>
@@ -60,22 +69,9 @@ you can put your changes in to the scene builder and you can see your results ac
                         </Button>
                      </children>
                   </VBox>
-                  <TextField id="code" fx:id="code" layoutX="39.0" layoutY="618.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
-                     <font>
-                        <Font name="Century Gothic Bold" size="17.0" />
-                     </font>
-                  </TextField>
-                  <Button fx:id="btn_submit_code" layoutX="151.0" layoutY="618.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
-                     <font>
-                        <Font name="Century Gothic Bold" size="20.0" />
-                     </font>
-                     <cursor>
-                        <Cursor fx:constant="HAND" />
-                     </cursor>
-                  </Button>
                </children>
             </AnchorPane>
-            <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="944.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" visible="false" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">
+            <TextArea id="mainPanel" fx:id="taCoursesTaken1" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="944.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" visible="false" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">
                <cursor>
                   <Cursor fx:constant="DEFAULT" />
                </cursor>
@@ -99,7 +95,7 @@ you can put your changes in to the scene builder and you can see your results ac
                            </HBox.margin>
                         </Label>
                         <Region prefHeight="45.0" prefWidth="617.0" HBox.hgrow="ALWAYS" />
-                        <Button id="Close_button" fx:id="Close_button" alignment="CENTER" mnemonicParsing="false" onAction="#closeApplication" onMouseClicked="#closeApplication" prefHeight="46.0" prefWidth="46.0" styleClass="Close_button" stylesheets="@MainWindowStyle.css" text="x" textAlignment="CENTER" textFill="WHITE" translateY="-2.0" visible="false" HBox.hgrow="ALWAYS">
+                        <Button id="Close_button" fx:id="Close_button1" alignment="CENTER" mnemonicParsing="false" onAction="#closeApplication" onMouseClicked="#closeApplication" prefHeight="46.0" prefWidth="46.0" styleClass="Close_button" stylesheets="@MainWindowStyle.css" text="x" textAlignment="CENTER" textFill="WHITE" translateY="-2.0" visible="false" HBox.hgrow="ALWAYS">
                            <font>
                               <Font name="Century Gothic Bold" size="20.0" />
                            </font>
@@ -121,12 +117,12 @@ you can put your changes in to the scene builder and you can see your results ac
                </font>
             </Text>
             <Line endX="711.5" layoutX="254.5" layoutY="48.0" startX="-252.0" stroke="WHITE" strokeWidth="5.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" />
-            <Text fill="WHITE" layoutX="23.0" layoutY="103.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Update login info">
+            <Text fill="WHITE" layoutX="23.0" layoutY="106.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Update login info">
                <font>
                   <Font name="Century Gothic Bold" size="30.0" />
                </font>
             </Text>
-            <Button fx:id="btn_login" alignment="CENTER" layoutX="266.0" layoutY="185.0" mnemonicParsing="false" onAction="#pressLoginButton" prefHeight="47.0" prefWidth="151.0" styleClass="general_button" stylesheets="@MainWindowStyle.css" text="  Login➧" textAlignment="CENTER" textFill="WHITE" textOverrun="CLIP">
+            <Button fx:id="btn_login" alignment="CENTER" layoutX="266.0" layoutY="193.0" mnemonicParsing="false" onAction="#pressLoginButton" prefHeight="47.0" prefWidth="151.0" styleClass="general_button" stylesheets="@MainWindowStyle.css" text="  Login➧" textAlignment="CENTER" textFill="WHITE" textOverrun="CLIP">
                <font>
                   <Font name="Century Gothic Bold" size="24.0" />
                </font>
@@ -154,6 +150,36 @@ you can put your changes in to the scene builder and you can see your results ac
                   <Font name="Century Gothic Bold" size="22.0" />
                </font>
             </Label>
+            <Line endX="711.5" layoutX="255.0" layoutY="323.0" startX="-252.0" stroke="WHITE" strokeWidth="3.0" />
+            <ToggleButton fx:id="toggle_selenium_bg" layoutX="298.0" layoutY="436.0" mnemonicParsing="false" onAction="#seleniumBackgroundButton" prefHeight="43.0" prefWidth="58.0" text="Off">
+               <cursor>
+                  <Cursor fx:constant="HAND" />
+               </cursor>
+               <font>
+                  <Font name="Century Gothic Bold" size="18.0" />
+               </font></ToggleButton>
+            <Label layoutX="80.0" layoutY="426.0" prefHeight="63.0" prefWidth="183.0" text="Open Selenium in background" textFill="WHITE" wrapText="true">
+               <font>
+                  <Font name="Century Gothic Bold" size="22.0" />
+               </font>
+            </Label>
+            <ToggleButton fx:id="toggle_save_cookies" layoutX="299.0" layoutY="505.0" mnemonicParsing="false" onAction="#saveCookiesButton" prefHeight="43.0" prefWidth="58.0" text="Off">
+               <cursor>
+                  <Cursor fx:constant="HAND" />
+               </cursor>
+               <font>
+                  <Font name="Century Gothic Bold" size="18.0" />
+               </font></ToggleButton>
+            <Label layoutX="81.0" layoutY="495.0" prefHeight="63.0" prefWidth="195.0" text="Save user cookies" textFill="WHITE" wrapText="true">
+               <font>
+                  <Font name="Century Gothic Bold" size="22.0" />
+               </font>
+            </Label>
+            <Text fill="WHITE" layoutX="23.0" layoutY="387.0" strokeType="OUTSIDE" strokeWidth="0.0" text="App settings">
+               <font>
+                  <Font name="Century Gothic Bold" size="30.0" />
+               </font>
+            </Text>
          </children>
       </AnchorPane>
    </children>

--- a/schedule-works-fe/src/main/resources/InterfaceLogin.fxml
+++ b/schedule-works-fe/src/main/resources/InterfaceLogin.fxml
@@ -3,41 +3,158 @@
 <!-- this fxml code is created through scene builder, you can edit the code here manually or
 you can put your changes in to the scene builder and you can see your results accordingly in here as well -->
 
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.Cursor?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.PasswordField?>
+<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.effect.Shadow?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.Line?>
 <?import javafx.scene.text.Font?>
+<?import javafx.scene.text.Text?>
 
 <AnchorPane prefHeight="400.0" prefWidth="550.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <fx:include source="Interface.fxml" />
-      <Button fx:id="btn_login" layoutX="566.0" layoutY="493.0" mnemonicParsing="false" onAction="#pressLoginButton" prefHeight="47.0" prefWidth="151.0" styleClass="general_button" stylesheets="@MainWindowStyle.css" text="Login" textFill="WHITE">
-         <font>
-            <Font name="Century Gothic Bold" size="24.0" />
-         </font>
-         <cursor>
-            <Cursor fx:constant="HAND" />
-         </cursor></Button>
-      <TextField fx:id="username" layoutX="566.0" layoutY="363.0" prefHeight="25.0" prefWidth="144.0" promptText="e.g ha9473" styleClass="code" stylesheets="@MainWindowStyle.css">
-         <font>
-            <Font name="Century Gothic Bold" size="12.0" />
-         </font></TextField>
-      <PasswordField fx:id="password" layoutX="568.0" layoutY="432.0" promptText="e.g *************" styleClass="code">
-         <font>
-            <Font name="Century Gothic Bold" size="12.0" />
-         </font></PasswordField>
-      <Label layoutX="572.0" layoutY="318.0" prefHeight="34.0" prefWidth="151.0" text="Access ID" textFill="WHITE">
-         <font>
-            <Font name="Century Gothic Bold" size="27.0" />
-         </font>
-      </Label>
-      <Label layoutX="571.0" layoutY="388.0" prefHeight="34.0" prefWidth="142.0" text="Password" textFill="WHITE">
-         <font>
-            <Font name="Century Gothic Bold" size="27.0" />
-         </font>
-      </Label>
+      <AnchorPane fx:id="scenePane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="1280.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+         <children>
+            <AnchorPane layoutY="52.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="598.0" prefWidth="277.0" style="-fx-background-color: #0F5F52;" AnchorPane.bottomAnchor="0.0" AnchorPane.topAnchor="52.0">
+               <children>
+                  <ImageView fitHeight="202.0" fitWidth="183.0" layoutX="47.0" layoutY="31.0" pickOnBounds="true" preserveRatio="true">
+                     <image>
+                        <Image url="@ScheduleWorksLogo.png" />
+                     </image>
+                     <effect>
+                        <Shadow />
+                     </effect>
+                  </ImageView>
+                  <ImageView fitHeight="187.0" fitWidth="178.0" layoutX="55.0" layoutY="37.0" pickOnBounds="true" preserveRatio="true">
+                     <image>
+                        <Image url="@ScheduleWorksLogo.png" />
+                     </image>
+                  </ImageView>
+                  <VBox layoutX="-1.0" layoutY="257.0" prefHeight="341.0" prefWidth="277.0">
+                     <children>
+                        <Button fx:id="btn_login_tab" graphicTextGap="0.0" mnemonicParsing="false" onAction="#pressLoginTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Login" textFill="WHITE">
+                           <font>
+                              <Font name="Century Gothic Bold" size="26.0" />
+                           </font>
+                           <cursor>
+                              <Cursor fx:constant="HAND" />
+                           </cursor>
+                        </Button>
+                        <Button fx:id="btn_retrieve_tab" mnemonicParsing="false" onAction="#retrieveCoursesTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Retrieve Courses" textFill="WHITE">
+                           <font>
+                              <Font name="Century Gothic Bold" size="26.0" />
+                           </font>
+                           <cursor>
+                              <Cursor fx:constant="HAND" />
+                           </cursor>
+                        </Button>
+                     </children>
+                  </VBox>
+                  <TextField id="code" fx:id="code" layoutX="39.0" layoutY="618.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
+                     <font>
+                        <Font name="Century Gothic Bold" size="17.0" />
+                     </font>
+                  </TextField>
+                  <Button fx:id="btn_submit_code" layoutX="151.0" layoutY="618.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
+                     <font>
+                        <Font name="Century Gothic Bold" size="20.0" />
+                     </font>
+                     <cursor>
+                        <Cursor fx:constant="HAND" />
+                     </cursor>
+                  </Button>
+               </children>
+            </AnchorPane>
+            <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="944.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" visible="false" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">
+               <cursor>
+                  <Cursor fx:constant="DEFAULT" />
+               </cursor>
+               <opaqueInsets>
+                  <Insets />
+               </opaqueInsets>
+               <font>
+                  <Font name="Century Gothic Bold" size="14.0" />
+               </font>
+            </TextArea>
+            <AnchorPane prefHeight="49.0" prefWidth="872.0" styleClass="topbar" stylesheets="@MainWindowStyle.css" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+               <children>
+                  <HBox alignment="CENTER_RIGHT" nodeOrientation="LEFT_TO_RIGHT" prefHeight="55.0" prefWidth="900.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+                     <children>
+                        <Label text="ScheduleWorks  " textAlignment="CENTER" textFill="WHITE" textOverrun="CLIP" HBox.hgrow="ALWAYS">
+                           <font>
+                              <Font name="Century Gothic Bold" size="29.0" />
+                           </font>
+                           <HBox.margin>
+                              <Insets />
+                           </HBox.margin>
+                        </Label>
+                        <Region prefHeight="45.0" prefWidth="617.0" HBox.hgrow="ALWAYS" />
+                        <Button id="Close_button" fx:id="Close_button" alignment="CENTER" mnemonicParsing="false" onAction="#closeApplication" onMouseClicked="#closeApplication" prefHeight="46.0" prefWidth="46.0" styleClass="Close_button" stylesheets="@MainWindowStyle.css" text="x" textAlignment="CENTER" textFill="WHITE" translateY="-2.0" visible="false" HBox.hgrow="ALWAYS">
+                           <font>
+                              <Font name="Century Gothic Bold" size="20.0" />
+                           </font>
+                        </Button>
+                     </children>
+                     <padding>
+                        <Insets bottom="5.0" left="10.0" right="10.0" top="5.0" />
+                     </padding>
+                  </HBox>
+               </children>
+            </AnchorPane>
+         </children>
+      </AnchorPane>
+      <AnchorPane fx:id="loginPane" layoutX="291.0" layoutY="69.0" prefHeight="716.0" prefWidth="973.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="291.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="69.0">
+         <children>
+            <Text id="userText" fx:id="userText" fill="WHITE" layoutX="2.0" layoutY="30.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Not currently logged in ⚠ ">
+               <font>
+                  <Font name="Century Gothic Bold" size="35.0" />
+               </font>
+            </Text>
+            <Line endX="729.0" layoutX="254.5" layoutY="48.0" startX="-252.0" stroke="WHITE" strokeWidth="5.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" />
+            <Text fill="WHITE" layoutX="23.0" layoutY="103.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Update login info">
+               <font>
+                  <Font name="Century Gothic Bold" size="30.0" />
+               </font>
+            </Text>
+            <Button fx:id="btn_login" alignment="CENTER" layoutX="266.0" layoutY="185.0" mnemonicParsing="false" onAction="#pressLoginButton" prefHeight="47.0" prefWidth="151.0" styleClass="general_button" stylesheets="@MainWindowStyle.css" text="  Login➧" textAlignment="CENTER" textFill="WHITE" textOverrun="CLIP">
+               <font>
+                  <Font name="Century Gothic Bold" size="24.0" />
+               </font>
+               <cursor>
+                  <Cursor fx:constant="HAND" />
+               </cursor>
+            </Button>
+            <TextField fx:id="username" layoutX="76.0" layoutY="179.0" prefHeight="25.0" prefWidth="144.0" promptText="e.g ha9473" styleClass="code" stylesheets="@MainWindowStyle.css">
+               <font>
+                  <Font name="Century Gothic Bold" size="12.0" />
+               </font>
+            </TextField>
+            <PasswordField fx:id="password" layoutX="78.0" layoutY="246.0" promptText="e.g *************" styleClass="code">
+               <font>
+                  <Font name="Century Gothic Bold" size="12.0" />
+               </font>
+            </PasswordField>
+            <Label layoutX="80.0" layoutY="139.0" prefHeight="34.0" prefWidth="151.0" text="Access ID" textFill="WHITE">
+               <font>
+                  <Font name="Century Gothic Bold" size="22.0" />
+               </font>
+            </Label>
+            <Label layoutX="81.0" layoutY="208.0" prefHeight="34.0" prefWidth="142.0" text="Password" textFill="WHITE">
+               <font>
+                  <Font name="Century Gothic Bold" size="22.0" />
+               </font>
+            </Label>
+         </children>
+      </AnchorPane>
    </children>
 </AnchorPane>

--- a/schedule-works-fe/src/main/resources/InterfaceLogin.fxml
+++ b/schedule-works-fe/src/main/resources/InterfaceLogin.fxml
@@ -113,14 +113,14 @@ you can put your changes in to the scene builder and you can see your results ac
             </AnchorPane>
          </children>
       </AnchorPane>
-      <AnchorPane fx:id="loginPane" layoutX="291.0" layoutY="69.0" prefHeight="716.0" prefWidth="973.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="291.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="69.0">
+      <AnchorPane fx:id="loginPane" layoutX="291.0" layoutY="69.0" prefHeight="716.0" prefWidth="986.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="291.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="69.0">
          <children>
             <Text id="userText" fx:id="userText" fill="WHITE" layoutX="2.0" layoutY="30.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Not currently logged in ⚠ ">
                <font>
                   <Font name="Century Gothic Bold" size="35.0" />
                </font>
             </Text>
-            <Line endX="729.0" layoutX="254.5" layoutY="48.0" startX="-252.0" stroke="WHITE" strokeWidth="5.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" />
+            <Line endX="711.5" layoutX="254.5" layoutY="48.0" startX="-252.0" stroke="WHITE" strokeWidth="5.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" />
             <Text fill="WHITE" layoutX="23.0" layoutY="103.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Update login info">
                <font>
                   <Font name="Century Gothic Bold" size="30.0" />

--- a/schedule-works-fe/src/main/resources/InterfaceLogin.fxml
+++ b/schedule-works-fe/src/main/resources/InterfaceLogin.fxml
@@ -3,76 +3,38 @@
 <!-- this fxml code is created through scene builder, you can edit the code here manually or
 you can put your changes in to the scene builder and you can see your results accordingly in here as well -->
 
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.Cursor?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.PasswordField?>
 <?import javafx.scene.control.TextField?>
-<?import javafx.scene.effect.Shadow?>
-<?import javafx.scene.image.Image?>
-<?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane prefHeight="400.0" prefWidth="550.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane prefHeight="400.0" prefWidth="550.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <Button fx:id="btn_login" layoutX="77.0" layoutY="278.0" mnemonicParsing="false" onAction="#pressLoginButton" prefHeight="47.0" prefWidth="151.0" styleClass="general_button" stylesheets="@MainWindowStyle.css" text="Login" textFill="WHITE">
+      <fx:include source="Interface.fxml" />
+      <Button fx:id="btn_login" layoutX="566.0" layoutY="493.0" mnemonicParsing="false" onAction="#pressLoginButton" prefHeight="47.0" prefWidth="151.0" styleClass="general_button" stylesheets="@MainWindowStyle.css" text="Login" textFill="WHITE">
          <font>
             <Font name="Century Gothic Bold" size="24.0" />
          </font>
          <cursor>
             <Cursor fx:constant="HAND" />
          </cursor></Button>
-      <TextField fx:id="username" layoutX="77.0" layoutY="148.0" prefHeight="25.0" prefWidth="144.0" promptText="e.g ha9473" styleClass="code" stylesheets="@MainWindowStyle.css">
+      <TextField fx:id="username" layoutX="566.0" layoutY="363.0" prefHeight="25.0" prefWidth="144.0" promptText="e.g ha9473" styleClass="code" stylesheets="@MainWindowStyle.css">
          <font>
             <Font name="Century Gothic Bold" size="12.0" />
          </font></TextField>
-      <PasswordField fx:id="password" layoutX="79.0" layoutY="217.0" promptText="e.g *************" styleClass="code">
+      <PasswordField fx:id="password" layoutX="568.0" layoutY="432.0" promptText="e.g *************" styleClass="code">
          <font>
             <Font name="Century Gothic Bold" size="12.0" />
          </font></PasswordField>
-      <AnchorPane prefHeight="10.0" prefWidth="550.0" styleClass="topbar" stylesheets="@MainWindowStyle.css">
-         <children>
-            <HBox alignment="CENTER_RIGHT" layoutX="1.0" layoutY="-3.0" prefHeight="23.0" prefWidth="550.0">
-               <children>
-                  <Label prefHeight="14.0" prefWidth="485.0" text="ScheduleWorks Login" textFill="WHITE">
-                     <font>
-                        <Font name="Century Gothic Bold" size="17.0" />
-                     </font>
-                  </Label>
-                  <Button id="Close_button" fx:id="Close_button" mnemonicParsing="false" onAction="#closeApplication" onMouseClicked="#closeApplication" prefHeight="22.0" prefWidth="46.0" styleClass="Close_button" stylesheets="@MainWindowStyle.css" text="X" textFill="WHITE">
-                     <font>
-                        <Font name="Century Gothic Bold" size="15.0" />
-                     </font>
-                  </Button>
-               </children>
-               <padding>
-                  <Insets bottom="5.0" left="10.0" right="10.0" top="5.0" />
-               </padding>
-            </HBox>
-         </children>
-      </AnchorPane>
-      <ImageView fitHeight="185.0" fitWidth="168.0" layoutX="337.0" layoutY="127.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@ScheduleWorksLogo.png" />
-         </image>
-         <effect>
-            <Shadow />
-         </effect>
-      </ImageView>
-      <ImageView fitHeight="181.0" fitWidth="164.0" layoutX="339.0" layoutY="129.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@ScheduleWorksLogo.png" />
-         </image>
-      </ImageView>
-      <Label layoutX="73.0" layoutY="102.0" prefHeight="34.0" prefWidth="151.0" text="Access ID" textFill="WHITE">
+      <Label layoutX="572.0" layoutY="318.0" prefHeight="34.0" prefWidth="151.0" text="Access ID" textFill="WHITE">
          <font>
             <Font name="Century Gothic Bold" size="27.0" />
          </font>
       </Label>
-      <Label layoutX="87.0" layoutY="179.0" prefHeight="34.0" prefWidth="142.0" text="Password" textFill="WHITE">
+      <Label layoutX="571.0" layoutY="388.0" prefHeight="34.0" prefWidth="142.0" text="Password" textFill="WHITE">
          <font>
             <Font name="Century Gothic Bold" size="27.0" />
          </font>

--- a/schedule-works-fe/src/main/resources/InterfaceRetrieve.fxml
+++ b/schedule-works-fe/src/main/resources/InterfaceRetrieve.fxml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Cursor?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.text.Font?>
+
+<!-- this fxml code is created through scene builder, you can edit the code here manually or
+you can put your changes in to the scene builder and you can see your results accordingly in here as well -->
+
+<AnchorPane fx:id="scenePane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="1280.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+   <children>
+      <fx:include source="Interface.fxml" />
+      <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="944.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">
+         <cursor>
+            <Cursor fx:constant="DEFAULT" />
+         </cursor>
+         <opaqueInsets>
+            <Insets />
+         </opaqueInsets>
+         <font>
+            <Font name="Century Gothic Bold" size="14.0" />
+         </font></TextArea>
+      <TextField id="code" fx:id="code" layoutX="389.0" layoutY="165.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
+         <font>
+            <Font name="Century Gothic Bold" size="17.0" />
+         </font>
+      </TextField>
+      <Button fx:id="btn_submit_code" layoutX="495.0" layoutY="165.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
+         <font>
+            <Font name="Century Gothic Bold" size="20.0" />
+         </font>
+         <cursor>
+            <Cursor fx:constant="HAND" />
+         </cursor>
+      </Button>
+   </children>
+</AnchorPane>

--- a/schedule-works-fe/src/main/resources/InterfaceRetrieve.fxml
+++ b/schedule-works-fe/src/main/resources/InterfaceRetrieve.fxml
@@ -13,6 +13,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.Line?>
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
@@ -111,34 +112,44 @@ you can put your changes in to the scene builder and you can see your results ac
             </AnchorPane>
          </children>
       </AnchorPane>
-      <Text fill="WHITE" layoutX="391.0" layoutY="384.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Enter the 2FA code below if prompted" textAlignment="CENTER" wrappingWidth="152.21875">
-         <font>
-            <Font name="Century Gothic Bold" size="20.0" />
-         </font>
-      </Text>
-      <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="660.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="591.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="660.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">
-         <cursor>
-            <Cursor fx:constant="DEFAULT" />
-         </cursor>
-         <opaqueInsets>
-            <Insets />
-         </opaqueInsets>
-         <font>
-            <Font name="Century Gothic Bold" size="14.0" />
-         </font>
-      </TextArea>
-      <TextField id="code" fx:id="code" layoutX="366.0" layoutY="455.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
-         <font>
-            <Font name="Century Gothic Bold" size="17.0" />
-         </font>
-      </TextField>
-      <Button fx:id="btn_submit_code" layoutX="472.0" layoutY="455.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
-         <font>
-            <Font name="Century Gothic Bold" size="20.0" />
-         </font>
-         <cursor>
-            <Cursor fx:constant="HAND" />
-         </cursor>
-      </Button>
+      <AnchorPane layoutX="291.0" layoutY="69.0" prefHeight="716.0" prefWidth="975.0" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="291.0" AnchorPane.rightAnchor="14.0" AnchorPane.topAnchor="69.0">
+         <children>
+            <Text id="userText" fill="WHITE" layoutX="2.0" layoutY="30.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Retrieve Courses">
+               <font>
+                  <Font name="Century Gothic Bold" size="35.0" />
+               </font>
+            </Text>
+            <Line endX="711.5" layoutX="255.0" layoutY="48.0" startX="-252.0" stroke="WHITE" strokeWidth="5.0" AnchorPane.bottomAnchor="665.5" AnchorPane.leftAnchor="0.5" AnchorPane.rightAnchor="6.0" AnchorPane.topAnchor="45.5" />
+            <Text fill="WHITE" layoutX="24.0" layoutY="104.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Enter the 2FA code below if prompted" wrappingWidth="357.21875">
+               <font>
+                  <Font name="Century Gothic Bold" size="25.0" />
+               </font>
+            </Text>
+            <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="440.0" layoutY="78.0" opacity="0.7" prefHeight="625.0" prefWidth="520.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" wrapText="true" AnchorPane.bottomAnchor="13.0" AnchorPane.leftAnchor="440.0" AnchorPane.rightAnchor="15.0" AnchorPane.topAnchor="78.0">
+               <cursor>
+                  <Cursor fx:constant="DEFAULT" />
+               </cursor>
+               <opaqueInsets>
+                  <Insets />
+               </opaqueInsets>
+               <font>
+                  <Font name="Century Gothic Bold" size="14.0" />
+               </font>
+            </TextArea>
+            <TextField id="code" fx:id="code" layoutX="24.0" layoutY="157.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
+               <font>
+                  <Font name="Century Gothic Bold" size="17.0" />
+               </font>
+            </TextField>
+            <Button fx:id="btn_submit_code" layoutX="130.0" layoutY="157.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
+               <font>
+                  <Font name="Century Gothic Bold" size="20.0" />
+               </font>
+               <cursor>
+                  <Cursor fx:constant="HAND" />
+               </cursor>
+            </Button>
+         </children>
+      </AnchorPane>
    </children>
 </AnchorPane>

--- a/schedule-works-fe/src/main/resources/InterfaceRetrieve.fxml
+++ b/schedule-works-fe/src/main/resources/InterfaceRetrieve.fxml
@@ -3,18 +3,120 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Cursor?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.effect.Shadow?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
+<?import javafx.scene.text.Text?>
 
 <!-- this fxml code is created through scene builder, you can edit the code here manually or
 you can put your changes in to the scene builder and you can see your results accordingly in here as well -->
 
 <AnchorPane fx:id="scenePane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="1280.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <fx:include source="Interface.fxml" />
-      <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="944.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">
+      <AnchorPane fx:id="scenePane1" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="1280.0" styleClass="scenePane" stylesheets="@MainWindowStyle.css" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+         <children>
+            <AnchorPane layoutY="52.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="598.0" prefWidth="277.0" style="-fx-background-color: #0F5F52;" AnchorPane.bottomAnchor="0.0" AnchorPane.topAnchor="52.0">
+               <children>
+                  <ImageView fitHeight="202.0" fitWidth="183.0" layoutX="47.0" layoutY="31.0" pickOnBounds="true" preserveRatio="true">
+                     <image>
+                        <Image url="@ScheduleWorksLogo.png" />
+                     </image>
+                     <effect>
+                        <Shadow />
+                     </effect>
+                  </ImageView>
+                  <ImageView fitHeight="187.0" fitWidth="178.0" layoutX="55.0" layoutY="37.0" pickOnBounds="true" preserveRatio="true">
+                     <image>
+                        <Image url="@ScheduleWorksLogo.png" />
+                     </image>
+                  </ImageView>
+                  <VBox layoutX="-1.0" layoutY="257.0" prefHeight="341.0" prefWidth="277.0">
+                     <children>
+                        <Button fx:id="btn_login_tab" graphicTextGap="0.0" mnemonicParsing="false" onAction="#pressLoginTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Login" textFill="WHITE">
+                           <font>
+                              <Font name="Century Gothic Bold" size="26.0" />
+                           </font>
+                           <cursor>
+                              <Cursor fx:constant="HAND" />
+                           </cursor>
+                        </Button>
+                        <Button fx:id="btn_retrieve_tab" mnemonicParsing="false" onAction="#retrieveCoursesTab" prefHeight="68.0" prefWidth="277.0" styleClass="general_button" text="Retrieve Courses" textFill="WHITE">
+                           <font>
+                              <Font name="Century Gothic Bold" size="26.0" />
+                           </font>
+                           <cursor>
+                              <Cursor fx:constant="HAND" />
+                           </cursor>
+                        </Button>
+                     </children>
+                  </VBox>
+                  <TextField id="code" fx:id="code1" layoutX="39.0" layoutY="618.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
+                     <font>
+                        <Font name="Century Gothic Bold" size="17.0" />
+                     </font>
+                  </TextField>
+                  <Button fx:id="btn_submit_code1" layoutX="151.0" layoutY="618.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
+                     <font>
+                        <Font name="Century Gothic Bold" size="20.0" />
+                     </font>
+                     <cursor>
+                        <Cursor fx:constant="HAND" />
+                     </cursor>
+                  </Button>
+               </children>
+            </AnchorPane>
+            <TextArea id="mainPanel" fx:id="taCoursesTaken1" editable="false" layoutX="307.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="944.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" visible="false" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="307.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">
+               <cursor>
+                  <Cursor fx:constant="DEFAULT" />
+               </cursor>
+               <opaqueInsets>
+                  <Insets />
+               </opaqueInsets>
+               <font>
+                  <Font name="Century Gothic Bold" size="14.0" />
+               </font>
+            </TextArea>
+            <AnchorPane prefHeight="49.0" prefWidth="872.0" styleClass="topbar" stylesheets="@MainWindowStyle.css" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+               <children>
+                  <HBox alignment="CENTER_RIGHT" nodeOrientation="LEFT_TO_RIGHT" prefHeight="55.0" prefWidth="900.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+                     <children>
+                        <Label text="ScheduleWorks  " textAlignment="CENTER" textFill="WHITE" textOverrun="CLIP" HBox.hgrow="ALWAYS">
+                           <font>
+                              <Font name="Century Gothic Bold" size="29.0" />
+                           </font>
+                           <HBox.margin>
+                              <Insets />
+                           </HBox.margin>
+                        </Label>
+                        <Region prefHeight="45.0" prefWidth="617.0" HBox.hgrow="ALWAYS" />
+                        <Button id="Close_button" fx:id="Close_button" alignment="CENTER" mnemonicParsing="false" onAction="#closeApplication" onMouseClicked="#closeApplication" prefHeight="46.0" prefWidth="46.0" styleClass="Close_button" stylesheets="@MainWindowStyle.css" text="x" textAlignment="CENTER" textFill="WHITE" translateY="-2.0" visible="false" HBox.hgrow="ALWAYS">
+                           <font>
+                              <Font name="Century Gothic Bold" size="20.0" />
+                           </font>
+                        </Button>
+                     </children>
+                     <padding>
+                        <Insets bottom="5.0" left="10.0" right="10.0" top="5.0" />
+                     </padding>
+                  </HBox>
+               </children>
+            </AnchorPane>
+         </children>
+      </AnchorPane>
+      <Text fill="WHITE" layoutX="391.0" layoutY="384.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Enter the 2FA code below if prompted" textAlignment="CENTER" wrappingWidth="152.21875">
+         <font>
+            <Font name="Century Gothic Bold" size="20.0" />
+         </font>
+      </Text>
+      <TextArea id="mainPanel" fx:id="taCoursesTaken" editable="false" layoutX="660.0" layoutY="83.0" opacity="0.7" prefHeight="689.0" prefWidth="591.0" styleClass="mainPanel" stylesheets="@MainWindowStyle.css" wrapText="true" AnchorPane.bottomAnchor="28.0" AnchorPane.leftAnchor="660.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="83.0">
          <cursor>
             <Cursor fx:constant="DEFAULT" />
          </cursor>
@@ -23,13 +125,14 @@ you can put your changes in to the scene builder and you can see your results ac
          </opaqueInsets>
          <font>
             <Font name="Century Gothic Bold" size="14.0" />
-         </font></TextArea>
-      <TextField id="code" fx:id="code" layoutX="389.0" layoutY="165.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
+         </font>
+      </TextArea>
+      <TextField id="code" fx:id="code" layoutX="366.0" layoutY="455.0" prefHeight="63.0" prefWidth="95.0" promptText="code" styleClass="code">
          <font>
             <Font name="Century Gothic Bold" size="17.0" />
          </font>
       </TextField>
-      <Button fx:id="btn_submit_code" layoutX="495.0" layoutY="165.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
+      <Button fx:id="btn_submit_code" layoutX="472.0" layoutY="455.0" mnemonicParsing="false" onAction="#submitCode" prefHeight="63.0" prefWidth="95.0" styleClass="general_button" text="Submit" textFill="WHITE">
          <font>
             <Font name="Century Gothic Bold" size="20.0" />
          </font>

--- a/schedule-works-fe/src/main/resources/MainWindowStyle.css
+++ b/schedule-works-fe/src/main/resources/MainWindowStyle.css
@@ -4,13 +4,19 @@
 
 .scenePane{
     -fx-background-color: linear-gradient(to bottom right,#42af9d,#e4ce0f);
-    
+    /* -fx-background-radius: 6px, 0px; */
 }
- -fx-background-radius: 6px, 0px;
+
+/* BUTTON CODE  */
 .button{
-    -fx-background-color: #FFCC33;
-    -fx-background-radius: 15px;
+    /* -fx-background-radius: 15px; */
     -fx-text-fill: #ffffff;
+}
+.button:hover{
+    -fx-background-color: #0b463c;
+}
+.button:pressed{
+    -fx-background-color: #FFCC33;
 }
 .mainPanel{
     -fx-background-color: #0b463c
@@ -36,6 +42,6 @@
 }
 
 .general_button{
-    -fx-background-radius: 15px;
-    -fx-background-color: #0b463c
+    /* -fx-background-radius: 15px; */
+    -fx-background-color: #0F5F52
 }

--- a/schedule-works-fe/src/main/resources/MainWindowStyle.css
+++ b/schedule-works-fe/src/main/resources/MainWindowStyle.css
@@ -14,23 +14,24 @@
 }
 .button:hover{
     -fx-background-color: #0b463c;
+    -fx-transition: 0.3s;
 }
 .button:pressed{
     -fx-background-color: #FFCC33;
 }
 .mainPanel{
-    -fx-background-color: #0b463c
+    -fx-background-color: #0b463c;
 }
 
 .topbar{
-    -fx-background-color: #0b463c
+    -fx-background-color: #0b463c;
     
 }
 .Close_button{
-    -fx-background-color: #0b463c
+    -fx-background-color: #0b463c;
 }
 .Close_button:hover{
-    -fx-background-color: #f30202
+    -fx-background-color: #f30202;
 }
 .code{
     -fx-background-radius: 15px;  
@@ -43,5 +44,5 @@
 
 .general_button{
     /* -fx-background-radius: 15px; */
-    -fx-background-color: #0F5F52
+    -fx-background-color: #0F5F52;
 }

--- a/schedule-works-fe/src/main/resources/MainWindowStyle.css
+++ b/schedule-works-fe/src/main/resources/MainWindowStyle.css
@@ -3,26 +3,41 @@
 }
 
 .scenePane{
-    -fx-background-color: linear-gradient(to bottom right,#42af9d,#e4ce0f);
+    -fx-background-color: linear-gradient(to bottom right,#42af9d,#dfca0f);
     /* -fx-background-radius: 6px, 0px; */
 }
 
-/* BUTTON CODE  */
+/*  BUTTON CODE  */
 .button{
     /* -fx-background-radius: 15px; */
     -fx-text-fill: #ffffff;
+    -fx-skin: 'org.scheduleworks.dep.SWButtonSkin'
 }
 .button:hover{
     -fx-background-color: #0b463c;
-    -fx-transition: 0.3s;
 }
 .button:pressed{
     -fx-background-color: #FFCC33;
 }
-.mainPanel{
+.toggle-button{
+    -fx-background-color: #6a6a6a;
+    -fx-text-fill: #ffffff;
+}
+.toggle-button:hover{
+    -fx-background-color: rgb(73, 73, 73);
+    -fx-text-fill: #ffffff;
+}
+.toggle-button:selected{
+    -fx-background-color: #0F5F52;
+    -fx-text-fill: #ffffff;
+}
+.toggle-button:pressed {
     -fx-background-color: #0b463c;
 }
 
+.mainPanel{
+    -fx-background-color: #0b463c;
+}
 .topbar{
     -fx-background-color: #0b463c;
     


### PR DESCRIPTION
- Changed the structure of the gui to support use of scene switching for multiple tabs/pages for content, as opposed to opening new scenes in new windows
- Redesigned interface layout and all pages to accommodate for scene switching, as well as to look more presentable
- Added app settings to the login page for later use ("Open Selenium in background" toggle, "Save user cookies" toggle)
- Added support for window resizing
- Added error handling to the Retrieve Courses page so that course retrieval won't be initiated unless the user is logged in
- Added a button skin class so that buttons can fade in and out slightly when hovered over
- Cleaned up redundant code